### PR TITLE
Update FilterBar.js

### DIFF
--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -30,6 +30,7 @@ const FilterBar = ({
           value={searchTerm}
           onChange={onChange}
           onKeyPress={onKeyPress}
+          spellcheck="false"
         />
         {searchTerm && (
           <button className={css.clearButton} onClick={onClick} type="button">


### PR DESCRIPTION
This issue is about the Filter feature on the Documentation page. When I type, for example, "textal" to search for the page for textAlign, my computer (macOS 13.1, Safari 16.2) autocompletes to "tectal". I wish it didn't! Out of habit, I press the return key (by habit e.g. using Google) so my computer autocompletes, and I don't see the page I'm looking for. The modification I suggest fixes this. I think it makes sense that code should not be autocompleted, and most of what I type into the filter input is code / a processing function I know exists.

What I did was make a local change on my browser to verify the behaviour i.e. that adding `spellcheck="false"` actually disables my browser's / my computer's spellcheck. Then I found the FilterBar.js and modified it. I'm assuming this changes the generated html files. I have not tested this i.e. I have not run the site locally using npm.